### PR TITLE
feat(parser): rationalize return items and expose some metadata

### DIFF
--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -1,7 +1,8 @@
 import type { HydrateFn } from './types';
 import { join } from 'path';
 import { readdirSync, readFileSync } from 'fs';
-import { compareDate, compareString } from './helper';
+import { isExists } from 'mauss/guards';
+import { compareString } from './helper';
 import { contentParser, countReadTime, extractMeta, generateTable, traverseCompare } from './utils';
 import marker from './marker';
 
@@ -33,22 +34,23 @@ export function parseFile<I, O = I>(pathname: string, hydrate: HydrateFn<I, O>):
 	return result as O;
 }
 
-export function parseDir<I, O = I>(dirname: string, hydrate: HydrateFn<I, O>): O[];
+export function parseDir<I, O = I>(dirname: string, hydrate: HydrateFn<I, O>): Array<O>;
 export function parseDir<I, O extends Record<string, any> = I>(
 	dirname: string,
 	hydrate: HydrateFn<I, O>
-): Array<O | undefined> {
+): Array<O> {
 	return readdirSync(dirname)
 		.filter((name) => !name.startsWith('draft.') && name.endsWith('.md'))
 		.map((filename) => parseFile(join(dirname, filename), hydrate))
+		.filter(isExists)
 		.sort((x, y) => {
 			if (x.date && y.date) {
 				if (typeof x.date === 'string' && typeof y.date === 'string')
 					if (x.date !== y.date) return compareString(x.date, y.date);
 				const { updated: xu, published: xp } = x.date;
 				const { updated: yu, published: yp } = y.date;
-				if (xu && yu && xu !== yu) return compareDate(xu, yu);
-				if (xp && yp && xp !== yp) return compareDate(xp, yp);
+				if (xu && yu && xu !== yu) return compareString(xu, yu);
+				if (xp && yp && xp !== yp) return compareString(xp, yp);
 			}
 			return traverseCompare(x, y);
 		});

--- a/src/internal/parser.ts
+++ b/src/internal/parser.ts
@@ -15,11 +15,11 @@ export function parseFile<I, O = I>(pathname: string, hydrate: HydrateFn<I, O>):
 	const metadata = extractMeta((match && match[1].trim()) || '');
 	const sliceIdx = match ? (match.index || 0) + match[0].length + 1 : 0;
 	const article = !match ? content : content.slice(sliceIdx);
+	metadata.toc = generateTable(article);
+	metadata.read_time = countReadTime(article);
 	const result = <typeof metadata>hydrate({ frontMatter: <I>metadata, content: article, filename });
 	if (!result) return;
 
-	result.toc = generateTable(article);
-	result.read_time = countReadTime(article);
 	if (result.date && result.date.published && !result.date.updated) {
 		result.date.updated = result.date.published;
 	}


### PR DESCRIPTION
- [Refactor] Change RegExp `exec` to string `match`
- [Feat] Make the return types of `parseDir` to be consistent by filtering undefined items out
- [Feat] Expose `toc` and `read_time` to metadata passed in hydrate callback function