### PR TITLE
fix(internal): options and error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "marqua",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@ignatiusmb/aqua": "^20.3.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marqua",
   "author": "Ignatius Bagus",
   "description": "Augmented Markdown Compiler",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "type": "module",
   "main": "index.js",

--- a/src/internal/compute.ts
+++ b/src/internal/compute.ts
@@ -19,7 +19,7 @@ export function structure(content: string, minimal: boolean): string | MarquaDat
 	if (minimal) return marker.render(content);
 	const tokens = marker.parse(content, {});
 	// TODO: Parse and Render Token Individually
-	return marker.renderer.render(tokens, {}, {});
+	return marker.renderer.render(tokens, marker.options, {});
 }
 
 export function table(content: string) {

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -11,12 +11,12 @@ export function compile<I, O extends Record<string, any> = I>(
 	options: string | FileOptions,
 	hydrate?: HydrateFn<I, O>
 ): O | undefined {
-	const { pathname, minimal = !1, exclude = [] } =
-		typeof options !== 'string' ? options : { pathname: options };
+	const { entry, minimal = !1, exclude = [] } =
+		typeof options !== 'string' ? options : { entry: options };
 
-	const crude = readFileSync(pathname, 'utf-8').trim();
+	const crude = readFileSync(entry, 'utf-8').trim();
 	const match = crude.match(/---\r?\n([\s\S]+?)\r?\n---/);
-	const [filename] = pathname.split(/[/\\]/).slice(-1);
+	const [filename] = entry.split(/[/\\]/).slice(-1);
 
 	const metadata = construct((match && match[1].trim()) || '');
 	const sliceIdx = match ? (match.index || 0) + match[0].length + 1 : 0;
@@ -39,16 +39,16 @@ export function compile<I, O extends Record<string, any> = I>(
 }
 
 export function traverse<I, O extends Record<string, any> = I>(
-	options: string | (DirOptions & FileOptions),
+	options: string | DirOptions,
 	hydrate?: HydrateFn<I, O>
 ): Array<O> {
-	const { dirname, extensions = ['.md'], ...config } =
-		typeof options !== 'string' ? options : { dirname: options };
+	const { entry, extensions = ['.md'], ...config } =
+		typeof options !== 'string' ? options : { entry: options };
 
-	if (!existsSync(dirname)) throw new Error(`Pathname ${dirname} does not exists!`);
-	return readdirSync(dirname)
+	if (!existsSync(entry)) throw new Error(`Pathname ${entry} does not exists!`);
+	return readdirSync(entry)
 		.filter((name) => !name.startsWith('draft.') && extensions.some((ext) => name.endsWith(ext)))
-		.map((filename) => compile({ pathname: join(dirname, filename), ...config }, hydrate))
+		.map((filename) => compile({ entry: join(entry, filename), ...config }, hydrate))
 		.filter(isExists)
 		.sort((x, y) => {
 			if (x.date && y.date) {

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -45,7 +45,8 @@ export function traverse<I, O extends Record<string, any> = I>(
 	const { entry, extensions = ['.md'], ...config } =
 		typeof options !== 'string' ? options : { entry: options };
 
-	if (!existsSync(entry)) throw new Error(`Pathname ${entry} does not exists!`);
+	if (!existsSync(entry)) return console.warn(`Path "${entry}" does not exists!`), [];
+
 	return readdirSync(entry)
 		.filter((name) => !name.startsWith('draft.') && extensions.some((ext) => name.endsWith(ext)))
 		.map((filename) => compile({ entry: join(entry, filename), ...config }, hydrate))

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,12 +1,11 @@
-export interface DirOptions {
-	dirname: string;
-	extensions?: Array<string>;
-}
-
 export interface FileOptions {
-	pathname: string;
+	entry: string;
 	minimal?: boolean;
 	exclude?: Array<string>;
+}
+export interface DirOptions extends FileOptions {
+	entry: string;
+	extensions?: Array<string>;
 }
 
 export interface HydrateFn<I, O = I> {


### PR DESCRIPTION
- merged `pathname` and `dirname` into `entry`
- pass in `marker.options` into renderer's render
- warn and return empty array instead of throwing
- bump patch version