### PR TITLE
fix: relocate postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "clean": "git add * && git clean -dfx -e node_modules",
     "lint": "pnpm --filter ./workspace/* lint",
     "test": "pnpm --filter ./workspace/* test",
-    "format": "pnpm --filter ./workspace/* format"
+    "format": "pnpm --filter ./workspace/* format",
+    "postinstall": "cd ./workspace/marqua && pnpm build"
   },
   "packageManager": "pnpm@7.18.2",
   "prettier": "mauss/prettier.json",

--- a/workspace/marqua/CHANGELOG.md
+++ b/workspace/marqua/CHANGELOG.md
@@ -1,5 +1,9 @@
 # marqua changelog
 
+## 0.4.1 - Unreleased
+
+- [#53](https://github.com/ignatiusmb/marqua/pull/53): remove `"postinstall"` script
+
 ## 0.4.0 - 2023/01/20
 
 - [#52](https://github.com/ignatiusmb/marqua/pull/52): specify `"engines"` field

--- a/workspace/marqua/package.json
+++ b/workspace/marqua/package.json
@@ -15,8 +15,7 @@
     "test": "pnpm test:core && pnpm test:apps",
     "test:core": "uvu -r tsm src \"(spec\\.ts)\"",
     "test:apps": "pnpm build && uvu test/apps",
-    "prepublish": "pnpm build && pnpm format",
-    "postinstall": "pnpm build"
+    "prepublish": "pnpm build && pnpm format"
   },
   "exports": {
     ".": "./core/index.js",


### PR DESCRIPTION
This was introduced in #48 to get the docs building, an oversight to not consider it running after `(p)npm install marqua` in user's projects as well