### PR TITLE
perf: use `exec` over `match`

### DIFF
--- a/workspace/documentation/src/routes/+page.server.ts
+++ b/workspace/documentation/src/routes/+page.server.ts
@@ -10,7 +10,7 @@ export const load: import('./$types').PageServerLoad = async () => {
 		({ breadcrumb: [filename], content, frontMatter: { title, ...rest } }) => {
 			if (filename.includes('draft')) return;
 			const path = `content/${filename}`;
-			const [, index, slug] = filename.match(/^(\d{2})-(.+).md$/) || [];
+			const [, index, slug] = /^(\d{2})-(.+).md$/.exec(filename) || [];
 			return { index, slug, title, ...rest, content, path };
 		}
 	);

--- a/workspace/marqua/src/artisan/marker.ts
+++ b/workspace/marqua/src/artisan/marker.ts
@@ -9,7 +9,7 @@ const marker = MarkIt({
 		const content: string[] = [];
 		const dataset: Record<string, string> = { lang };
 		for (const line of source.split('\n')) {
-			const match = line.match(/^#\$ (\w+): (.+)/);
+			const match = /^#\$ (\w+): (.+)/.exec(line);
 			if (!match) content.push(line);
 			else dataset[match[1]] = match[2]?.trim() || '';
 		}
@@ -37,15 +37,15 @@ marker.renderer.rules.image = (tokens, idx, options, env, self) => {
 	const alt = token.attrGet('alt') || '';
 	const media = {
 		data: '',
-		type: (alt.match(/^!(\w+[-\w]+)($|#)/) || ['', ''])[1],
-		attrs: (alt.match(/#(\w+)/g) || []).map((a) => a.slice(1)),
+		type: (/^!(\w+[-\w]+)($|#)/.exec(alt) || [, ''])[1],
+		attrs: (/#(\w+)/g.exec(alt) || []).map((a) => a.slice(1)),
 	};
 
 	if (media.type) {
 		const stripped = media.type.toLowerCase();
 		const [type, ...args] = stripped.split('-');
 		if (['yt', 'youtube'].includes(type)) {
-			const [, yid, params = ''] = link.match(/([-\w]+)\??(.+)?$/) || [];
+			const [, yid, params = ''] = /([-\w]+)\??(.+)?$/.exec(link) || [];
 			const prefix = args.length && args.includes('s') ? 'videoseries?list=' : '';
 			media.data = prefix
 				? `<iframe src="https://www.youtube-nocookie.com/embed/${prefix}${link}" frameborder="0" allowfullscreen title="${caption}"></iframe>`

--- a/workspace/marqua/src/core/index.ts
+++ b/workspace/marqua/src/core/index.ts
@@ -9,7 +9,7 @@ export function construct(raw: string): FrontMatterIndex {
 	const index: FrontMatterIndex = {};
 
 	for (const line of raw.split(/\r?\n/).filter(exists)) {
-		const match = line.trim().match(/([:\w\d]+): (.+)/);
+		const match = /([:\w\d]+): (.+)/.exec(line.trim());
 		if (!match || (match && !match[2].trim())) continue;
 
 		const [key, data] = match.slice(1).map((g) => g.trim());
@@ -29,7 +29,7 @@ export function construct(raw: string): FrontMatterIndex {
 }
 
 export function parse(source: string) {
-	const match = source.match(/---\r?\n([\s\S]+?)\r?\n---/);
+	const match = /---\r?\n([\s\S]+?)\r?\n---/.exec(source);
 	const crude = source.slice(match ? (match.index || 0) + match[0].length + 1 : 0);
 	const memory = construct((match && match[1].trim()) || '');
 
@@ -46,7 +46,7 @@ export function parse(source: string) {
 					const accumulated = line.split(' ').filter((w) => !!w && /\w|\d/.test(w) && w.length > 1);
 					return total + accumulated.length;
 				}, 0);
-				const images = crude.match(/!\[.+\]\(.+\)/g);
+				const images = /!\[.+\]\(.+\)/g.exec(crude);
 				const total = words + (images || []).length * 12;
 				return Math.round(total / 240) || 1;
 			},
@@ -56,7 +56,7 @@ export function parse(source: string) {
 				const lines: RegExpMatchArray[] = [];
 				const counter = [0, 0, 0];
 				for (const line of crude.split('\n')) {
-					const match = line.trim().match(/^(#{2,4}) (.+)/);
+					const match = /^(#{2,4}) (.+)/.exec(line.trim());
 					if (match) lines.push(match), counter[match[1].length - 2]++;
 				}
 				const alone = counter.filter((i) => i === 0).length === 2;


### PR DESCRIPTION
A simple benchmark shows `exec` is faster than `match` by a factor of almost 4 times, though it wouldn't really matter in small or simple cases, this is still quite an interesting find to me, and I'll probably always prefer `exec` over `match` going forward.

***

```
.exec(): 23.149ms
.match(): 89.175ms
```

The benchmark code

```js
const regex = /\d+/;
const str = 'hello 123 world 456';

console.time('.exec()');
let match;
for (let i = 0; i < 1000000; i++) {
  match = regex.exec(str);
}
console.timeEnd('.exec()');

console.time('.match()');
for (let i = 0; i < 1000000; i++) {
  match = str.match(regex);
}
console.timeEnd('.match()');
```