### PR TITLE
fix: differentiate `buffer` in compile's tree

### DIFF
--- a/workspace/marqua/src/fs/index.js
+++ b/workspace/marqua/src/fs/index.js
@@ -21,6 +21,7 @@ export function compile(entry, hydrate) {
 				if (fs.lstatSync(path).isDirectory()) {
 					return { type: 'directory', name, path };
 				}
+				const buffer = fs.readFileSync(path);
 				return { type: 'file', name, path, buffer };
 			});
 			return hydrate({ breadcrumb, buffer, parse, siblings: tree });


### PR DESCRIPTION
Too much is going on in `compile` function, it will be trimmed down to the bare minimum in the upcoming `v0.6.0`